### PR TITLE
Add setting to embed thumbnail into the file

### DIFF
--- a/YtDlpExtension/Helpers/DownloadHelper.cs
+++ b/YtDlpExtension/Helpers/DownloadHelper.cs
@@ -536,13 +536,18 @@ namespace YtDlpExtension.Helpers
                 arguments.Add($"--download-sections \"*{startTime}-{endTime}\"");
             }
 
+            if (_settings.GetEmbedThumbnail)
+            {
+                arguments.Add("--embed-thumbnail");
+            }
+
             arguments.Add($"\"{url}\"");
 
             var argumentsFinal = string.Join(" ", arguments);
             //var debugBanner = new StatusMessage();
             //debugBanner.UpdateState(DownloadState.CustomMessage, argumentsFinal, true);
             //debugBanner.ShowStatus();
-            var shouldRedirect = isLive ? false : true;
+            var shouldRedirect = !isLive;
             var psi = new ProcessStartInfo
             {
                 FileName = "yt-dlp",

--- a/YtDlpExtension/Helpers/SettingsManager.cs
+++ b/YtDlpExtension/Helpers/SettingsManager.cs
@@ -85,6 +85,10 @@ namespace YtDlpExtension.Helpers
             Description = "Always recode video (Increases time but ensures compatibility)"
         };
 
+        private readonly ToggleSetting _embedThumbnail = new("embedThumbnail", true)
+        {
+            Label = "EmbedThumbnail".ToLocalized(),
+        };
 
         private readonly ChoiceSetSetting _mode = new("mode", [
                 new ChoiceSetSetting.Choice("Simple", ExtensionMode.SIMPLE),
@@ -159,6 +163,7 @@ namespace YtDlpExtension.Helpers
         public string GetCookiesFile => _cookiesFileLocation.Value ?? string.Empty;
         public string GetSelectedMode => _mode.Value ?? ExtensionMode.SIMPLE;
         public bool GetDownloadOnPaste => _downloadOnPaste.Value;
+        public bool GetEmbedThumbnail => _embedThumbnail.Value;
         public string GetCustomFormatSelector => _customFormatSelector.Value ?? string.Empty;
         internal static string SettingsJsonPath()
         {
@@ -177,6 +182,8 @@ namespace YtDlpExtension.Helpers
             Settings.Add(_cookiesFileLocation);
             Settings.Add(_customFormatSelector);
             Settings.Add(_downloadOnPaste);
+            Settings.Add(_embedThumbnail);
+
             try
             {
                 LoadSettings();

--- a/YtDlpExtension/Strings/en-US/Resources.resw
+++ b/YtDlpExtension/Strings/en-US/Resources.resw
@@ -190,6 +190,9 @@ Provide the cookies file in the Settings page to proceed.</value>
   <data name="DownloadingSubtitle" xml:space="preserve">
     <value>Downloading subtitle: {0}</value>
   </data>
+  <data name="EmbedThumbnail" xml:space="preserve">
+    <value>Embed thumbnail</value>
+  </data>
   <data name="EmptyContentTiltle" xml:space="preserve">
     <value>Paste an URL to start.</value>
   </data>

--- a/YtDlpExtension/Strings/pt-BR/Resources.resw
+++ b/YtDlpExtension/Strings/pt-BR/Resources.resw
@@ -190,6 +190,9 @@ Adicione o arquivo de cookies nas configurações para prosseguir.</value>
   <data name="DownloadingSubtitle" xml:space="preserve">
     <value>Baixando legenda: {0}</value>
   </data>
+  <data name="EmbedThumbnail" xml:space="preserve">
+    <value>Incorporar thumbnail</value>
+  </data>
   <data name="EmptyContentTiltle" xml:space="preserve">
     <value>Cole uma URL para começar.</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request
This PR aims to fix #1 

### Features
Added a new configuration option that allows **embedding thumbnails** into the metadata of downloaded video and audio files.
(default: `true`)